### PR TITLE
feat: enhance REPL banner centering and improve index.html SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,30 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <meta name="color-scheme" content="dark">
-<meta name="description" content="Forge — wiki · local-first, multi-agent, programmable software-engineering CLI runtime.">
+<title>Forge | Local-first, multi-agent, programmable software-engineering runtime</title>
+<meta name="description" content="Forge - A local-first, multi-agent, programmable software-engineering CLI runtime.">
+<meta name="keywords" content="Forge, CLI, AI agent, local-first, multi-agent, software engineering, LLM, coding assistant, open source, developer tools, typescript, runtime">
+<meta name="author" content="Forge Contributors">
+<meta name="robots" content="index, follow">
+
+<!-- Open Graph / Facebook -->
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://github.com/hoangsonw/Forge-Agentic-Coding-CLI">
+<meta property="og:title" content="Forge | Local-first, multi-agent, programmable software-engineering runtime">
+<meta property="og:description" content="Forge - A local-first, multi-agent, programmable software-engineering CLI runtime.">
+<meta property="og:image" content="https://opengraph.githubassets.com/1/hoangsonw/Forge-Agentic-Coding-CLI">
+
+<!-- Twitter -->
+<meta property="twitter:card" content="summary_large_image">
+<meta property="twitter:url" content="https://github.com/hoangsonw/Forge-Agentic-Coding-CLI">
+<meta property="twitter:title" content="Forge | Local-first, multi-agent, programmable software-engineering runtime">
+<meta property="twitter:description" content="Forge - A local-first, multi-agent, programmable software-engineering CLI runtime.">
+<meta property="twitter:image" content="https://opengraph.githubassets.com/1/hoangsonw/Forge-Agentic-Coding-CLI">
+
+<!-- Theme & Icons -->
 <meta name="theme-color" content="#0891b2">
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='100' y2='100' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='0' stop-color='%232dd4bf'/%3E%3Cstop offset='1' stop-color='%230891b2'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='100' height='100' rx='22' fill='url(%23g)'/%3E%3Cpath d='M25 20 L75 20 L75 34 L40 34 L40 46 L65 46 L65 58 L40 58 L40 80 L25 80 Z' fill='white'/%3E%3C/svg%3E">
-<title>Forge — Wiki</title>
+<link rel="canonical" href="https://github.com/hoangsonw/Forge-Agentic-Coding-CLI">
 <link rel="stylesheet" href="wiki/styles.css">
 </head>
 <body>
@@ -62,7 +82,7 @@
     </p>
     <div class="cta">
       <a class="btn primary" href="#install">Install Forge →</a>
-      <a class="btn" href="#loop">Read the wiki</a>
+      <a class="btn" href="#overview">Read the wiki</a>
       <a class="btn" href="https://github.com/hoangsonw/Forge-Agentic-Coding-CLI">GitHub</a>
     </div>
     <div class="hero-stats">

--- a/src/cli/banners.ts
+++ b/src/cli/banners.ts
@@ -60,6 +60,12 @@ const gradientLines = (
 
 /** The primary brand banner. Matches the ASCII the user requested exactly. */
 export const banner = (): string => {
+  const cols = process.stdout.columns && process.stdout.columns > 0 ? process.stdout.columns : 80;
+  const center = (text: string, rawLength: number) => {
+    const pad = Math.max(0, Math.floor((cols - rawLength) / 2));
+    return ' '.repeat(pad) + text;
+  };
+
   const art = [
     `.------------------------------.`,
     `| _____                        |`,
@@ -70,28 +76,47 @@ export const banner = (): string => {
     `|                  |___/       |`,
     `'------------------------------'`,
   ];
-  const coloured = gradientLines(art, PALETTE.cyan, PALETTE.violet).join('\n');
-  const tagline = chalk.rgb(...PALETTE.muted)('    local-first · multi-agent · programmable');
-  const subtitle = chalk
-    .rgb(...PALETTE.pink)
-    .italic('    forge — software engineering as a runtime');
+  const coloured = gradientLines(art, PALETTE.cyan, PALETTE.violet)
+    .map((line, i) => center(line, art[i].length))
+    .join('\n');
+
+  const subtitleRaw = 'forge — software engineering as a runtime';
+  const subtitle = center(chalk.rgb(...PALETTE.pink).italic(subtitleRaw), subtitleRaw.length);
+
+  const taglineRaw = 'local-first · multi-agent · programmable';
+  const tagline = center(chalk.rgb(...PALETTE.muted)(taglineRaw), taglineRaw.length);
+
   return `\n${coloured}\n${subtitle}\n${tagline}\n`;
 };
 
 /** Welcome hero used by `forge init` and a blank `forge`. */
 export const welcome = (version: string): string => {
+  const cols = process.stdout.columns && process.stdout.columns > 0 ? process.stdout.columns : 80;
+  const center = (text: string, rawLength: number) => {
+    const pad = Math.max(0, Math.floor((cols - rawLength) / 2));
+    return ' '.repeat(pad) + text;
+  };
+
   const left = chalk.rgb(...PALETTE.cyan)('⟡');
   const right = chalk.rgb(...PALETTE.pink)('⟡');
   const v = chalk.rgb(...PALETTE.muted)(`v${version}`);
-  const header = `${banner()}${' '.repeat(6)}${left} ${chalk.bold('Welcome to Forge')} ${right}  ${v}\n`;
-  const hint =
-    chalk.rgb(...PALETTE.muted)('    try: ') +
-    chalk.bold.rgb(...PALETTE.cyan)('forge run ') +
-    chalk.rgb(...PALETTE.amber)('"add a /health endpoint"') +
-    chalk.rgb(...PALETTE.muted)('   ·   ') +
-    chalk.bold.rgb(...PALETTE.cyan)('forge ui start') +
-    '\n';
-  return header + hint;
+  const welcomeRaw = `⟡ Welcome to Forge ⟡  v${version}`;
+  const headerLine = center(
+    `${left} ${chalk.bold('Welcome to Forge')} ${right}  ${v}`,
+    welcomeRaw.length,
+  );
+
+  const hintRaw = `try: forge run "add a /health endpoint"   ·   forge ui start`;
+  const hintLine = center(
+    chalk.rgb(...PALETTE.muted)('try: ') +
+      chalk.bold.rgb(...PALETTE.cyan)('forge run ') +
+      chalk.rgb(...PALETTE.amber)('"add a /health endpoint"') +
+      chalk.rgb(...PALETTE.muted)('   ·   ') +
+      chalk.bold.rgb(...PALETTE.cyan)('forge ui start'),
+    hintRaw.length,
+  );
+
+  return `${banner()}${headerLine}\n${hintLine}\n`;
 };
 
 /** Heavy divider with gradient and optional title. */


### PR DESCRIPTION
This pull request improves both the web and CLI user experience by enhancing SEO and social sharing metadata in `index.html` and updating the CLI banner and welcome output to be centered according to the terminal width. These changes help make the project more discoverable online and provide a more polished, professional feel for CLI users.

**Web/SEO improvements:**

- Added comprehensive meta tags to `index.html` for SEO, social sharing (Open Graph, Twitter), author, and robots, and updated the page title and canonical link for better discoverability and presentation.
- Changed the "Read the wiki" button anchor from `#loop` to `#overview` for improved navigation.

**CLI output improvements:**

- Updated `src/cli/banners.ts` so that the CLI banner, subtitle, tagline, welcome message, and hint are all horizontally centered based on the detected terminal width, resulting in a more visually appealing and balanced output. [[1]](diffhunk://#diff-405ffc79545d6421036e0ebf5e4c363d4173193d92dc852685f8900b39e8811fR63-R68) [[2]](diffhunk://#diff-405ffc79545d6421036e0ebf5e4c363d4173193d92dc852685f8900b39e8811fL73-R119)