### PR TITLE
chore: remove affiliation from CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,6 @@ authors:
     family-names: Nguyen
     alias: hoangsonww
     email: hoangson091104@gmail.com
-    affiliation: "LexisNexis"
 repository-code: "https://github.com/hoangsonww/Forge-Agentic-Coding-CLI"
 url: "https://github.com/hoangsonww/Forge-Agentic-Coding-CLI"
 license: MIT


### PR DESCRIPTION
This pull request makes a minor update to the `CITATION.cff` file, specifically removing the `affiliation` field for one of the authors. This simplifies the author metadata in the citation file.