### PR TITLE
chore: refine responsive styles for hero-stats grid on mobile devices

### DIFF
--- a/wiki/styles.css
+++ b/wiki/styles.css
@@ -549,15 +549,40 @@ ul li {
 }
 
 @media (max-width: 720px) {
-  .hero-stats { grid-template-columns: repeat(2, 1fr); gap: 2px; }
-  .hero-stat  { border-right: 0; border-bottom: 1px solid var(--border); padding: 12px 0; }
-  .hero-stat:first-child            { padding-top: 0; }
-  .hero-stat:nth-last-child(-n + 2) { border-bottom: 0; }
-  .hero-stat:nth-last-child(2)      { padding-left: 18px; border-left: 1px solid var(--border); }
+  /* Zero the container's padding-top so the vertical divider (border-left on
+     even items) starts exactly at the border-top line with no gap. */
+  .hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0;
+    padding-top: 0;
+  }
+  .hero-stat  {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+    /* Uniform top padding on all items keeps rows aligned within their cells */
+    padding: 16px 0;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+  /* Right-column items: left divider connects with border-top since padding-top is on the items */
+  .hero-stat:nth-child(even) {
+    padding-left: 20px;
+    border-left: 1px solid var(--border);
+  }
+  /* Remove bottom border from last paired row AND lone item below it */
+  .hero-stat:nth-last-child(-n + 3) { border-bottom: 0; }
+  /* Lone 5th item: span full width, center content, clear left styles */
+  .hero-stat:last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+    text-align: center;
+    border-left: 0;
+    padding-left: 0;
+  }
 }
 
 @media (max-width: 480px) {
   .hero-stats { grid-template-columns: 1fr 1fr; }
+  .hero-stat .n { font-size: clamp(14px, 5vw, 20px); }
 }
 
 /* =============================================================================


### PR DESCRIPTION
This pull request updates the responsive styles for the `.hero-stats` and `.hero-stat` components in `wiki/styles.css` to improve layout consistency and visual alignment, especially on smaller screens. The changes focus on refining grid and padding behavior, ensuring divider lines align correctly, and handling edge cases for odd numbers of stats.

**Responsive layout and alignment improvements:**

* Refactored the `.hero-stats` grid for screens under 720px to remove vertical gaps, set `padding-top: 0`, and ensure vertical dividers (borders) align perfectly with the top border.
* Updated `.hero-stat` items to use uniform top padding (`16px`), set `min-width: 0`, and use `box-sizing: border-box` for better cell alignment.
* Changed right-column items (`.hero-stat:nth-child(even)`) to use a left border and left padding, ensuring the divider line connects with the top border.
* Improved handling of the last row and lone items: removed the bottom border from the last three stats and made a lone fifth stat span the full width, center its content, and clear left-side styles.

**Mobile font scaling:**

* Added a responsive font size for `.hero