### PR TITLE
fix: add Drive overlay button to demo videos for alternative access

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,21 +266,30 @@
 
     <div class="code-win" style="margin: 0 0 32px; display: flex; flex-direction: column;">
       <div class="titlebar"><div class="traffic"><i></i><i></i><i></i></div><span class="ttl">REPL demo · forge</span></div>
-      <video src="https://github.com/user-attachments/assets/eb592bbf-62a1-4d74-a540-7e066ebe56a4
+      <div class="video-wrap" style="position:relative">
+        <video src="https://github.com/user-attachments/assets/eb592bbf-62a1-4d74-a540-7e066ebe56a4
 " poster="images/repl.png" controls muted playsinline preload="metadata"
              style="display:block;width:100%;max-height:70vh;height:auto;object-fit:contain;background:#000"></video>
+        <a class="video-overlay-btn" href="https://drive.google.com/drive/folders/1YJLQblgGl_2fNZ0-8-lX9TvQsGGZ12sn?usp=sharing" target="_blank" rel="noopener noreferrer" title="Open all demos on Google Drive">Drive</a>
+      </div>
     </div>
     <div class="code-win" style="margin: 0 0 32px; display: flex; flex-direction: column;">
       <div class="titlebar"><div class="traffic"><i></i><i></i><i></i></div><span class="ttl">CLI demo · forge run</span></div>
-      <video src="https://github.com/user-attachments/assets/bc3b3204-fd87-436f-9467-604535edb4e2
+      <div class="video-wrap" style="position:relative">
+        <video src="https://github.com/user-attachments/assets/bc3b3204-fd87-436f-9467-604535edb4e2
 " poster="images/cli.png" controls muted playsinline preload="metadata"
              style="display:block;width:100%;max-height:70vh;height:auto;object-fit:contain;background:#000"></video>
+        <a class="video-overlay-btn" href="https://drive.google.com/drive/folders/1YJLQblgGl_2fNZ0-8-lX9TvQsGGZ12sn?usp=sharing" target="_blank" rel="noopener noreferrer" title="Open all demos on Google Drive">Drive</a>
+      </div>
     </div>
     <div class="code-win" style="margin: 0; display: flex; flex-direction: column;">
       <div class="titlebar"><div class="traffic"><i></i><i></i><i></i></div><span class="ttl">Web dashboard demo · forge ui start</span></div>
-      <video src="https://github.com/user-attachments/assets/218cd64f-40fe-4836-9c62-c7a08538056b
+      <div class="video-wrap" style="position:relative">
+        <video src="https://github.com/user-attachments/assets/218cd64f-40fe-4836-9c62-c7a08538056b
 " poster="images/ui.png" controls muted playsinline preload="metadata"
              style="display:block;width:100%;height:auto;background:#000"></video>
+        <a class="video-overlay-btn" href="https://drive.google.com/drive/folders/1YJLQblgGl_2fNZ0-8-lX9TvQsGGZ12sn?usp=sharing" target="_blank" rel="noopener noreferrer" title="Open all demos on Google Drive">Drive</a>
+      </div>
     </div>
   </div>
 </section>

--- a/wiki/styles.css
+++ b/wiki/styles.css
@@ -1028,6 +1028,73 @@ section.alt {
   white-space: pre;
 }
 
+/* Top-right "↗ Drive" overlay on demo videos. Positioned over the player
+   so users who can't load the inline GitHub-hosted MP4 (corp proxies, etc.)
+   have a one-click escape hatch to the same clips on Google Drive. */
+.video-overlay-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 13px 7px 11px;
+  font: 600 11.5px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: #f5f7fb;
+  background:
+    linear-gradient(180deg, rgba(28, 38, 58, 0.92) 0%, rgba(10, 14, 22, 0.92) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  text-decoration: none;
+  /* Soft inner highlight on top edge + outer drop shadow so the chip reads
+     clearly over both bright and dark video frames. */
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.08) inset,
+    0 0 0 1px rgba(0, 0, 0, 0.25),
+    0 4px 14px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(8px) saturate(1.2);
+  -webkit-backdrop-filter: blur(8px) saturate(1.2);
+  transition:
+    background .18s var(--ease, ease),
+    border-color .18s var(--ease, ease),
+    transform .18s var(--ease, ease),
+    box-shadow .18s var(--ease, ease);
+  pointer-events: auto;
+}
+/* Lift the arrow glyph optically — it sits on the baseline by default
+   which makes it look low next to the uppercase text. translateY -1.5px
+   centers its visual mass with the cap-height of "DRIVE". */
+.video-overlay-btn::before {
+  content: "↗";
+  font-size: 13px;
+  line-height: 1;
+  color: #9cc2ff;
+  transform: translateY(-1.5px);
+  display: inline-block;
+  transition: transform .18s var(--ease, ease), color .18s var(--ease, ease);
+}
+.video-overlay-btn:hover {
+  background:
+    linear-gradient(180deg, rgba(38, 56, 92, 0.96) 0%, rgba(14, 20, 32, 0.96) 100%);
+  border-color: rgba(124, 184, 255, 0.55);
+  transform: translateY(-1px);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.12) inset,
+    0 0 0 1px rgba(0, 0, 0, 0.3),
+    0 6px 18px rgba(0, 0, 0, 0.55);
+}
+.video-overlay-btn:hover::before {
+  color: #cfe0ff;
+  transform: translateY(-2.5px) translateX(0.5px);
+}
+.video-overlay-btn:focus-visible {
+  outline: 2px solid var(--accent, #7cb8ff);
+  outline-offset: 2px;
+}
+
 .code-win pre .dim  { color: var(--fg3); }
 .code-win pre .ok   { color: var(--teal); }
 .code-win pre .warn { color: var(--orange); }


### PR DESCRIPTION
This pull request improves the user experience for demo videos on the site by adding a visible overlay button that links directly to Google Drive copies of each demo. This provides an easy alternative for users who may have trouble playing the inline GitHub-hosted videos (for example, due to corporate proxies).

Key changes:

**Feature addition:**
* Added a "Drive" overlay button (`.video-overlay-btn`) above each demo video in `index.html`, linking to a Google Drive folder containing all demo clips. This gives users a one-click fallback if the embedded video doesn't play.

**Styling and accessibility:**
* Introduced comprehensive CSS styles in `wiki/styles.css` for the overlay button, ensuring it is visually distinct, accessible, and remains readable over any video frame. The overlay includes a top-right position, a ↗ arrow icon, hover/focus states, and a drop shadow for clarity.