### PR TITLE
feat(mcp): expose Forge as an MCP server (forge mcp serve)

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,23 @@ forge mcp status
 Both `stdio` and HTTP-stream transports supported. OAuth 2.0 + PKCE or
 API key auth. Tokens stored in the OS keychain.
 
+### Forge as an MCP server
+
+Forge can also run *as* an MCP server, not just consume them. Drop this into your Claude Desktop / Cursor / Continue config and the calling agent gets `forge_status`, `forge_plan`, `forge_get_task`, `forge_list_tasks` (read-only by default) plus `forge_run` and `forge_cancel_task` when started with `--allow-execute`:
+
+```json
+{
+  "mcpServers": {
+    "forge": {
+      "command": "forge",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Full reference, security model, and per-client setup: [`docs/MCP-SERVER.md`](docs/MCP-SERVER.md).
+
 ---
 
 ## Run in a container (Docker or Podman)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,6 +19,7 @@
 - [8. Conversation & persistence](#8-conversation--persistence)
 - [9. UI topology](#9-ui-topology)
   - [9.1 VS Code extension](#91-vs-code-extension)
+  - [9.2 MCP server (`forge mcp serve`)](#92-mcp-server-forge-mcp-serve)
 - [10. CI/CD pipeline](#10-cicd-pipeline)
 - [11. Deployment topologies](#11-deployment-topologies)
 - [12. Runtime metrics at a glance](#12-runtime-metrics-at-a-glance)
@@ -44,6 +45,7 @@ flowchart TB
     REPL["REPL (raw-mode editor)"]:::surface
     UI["Dashboard (HTTP + WS)"]:::surface
     VSCX["VS Code extension<br/>(vscode-extension/)"]:::surface
+    MCPS["MCP server<br/>(forge mcp serve)"]:::surface
   end
 
   ORCH["Orchestrator<br/>src/core/orchestrator.ts"]:::core
@@ -108,6 +110,7 @@ Code it maps to:
 | REPL | `src/cli/repl.ts` + `src/cli/repl-input.ts` |
 | UI | `src/ui/server.ts` + `src/ui/public/` |
 | VS Code extension | `vscode-extension/` (separate npm package, ships to the VS Code Marketplace) |
+| MCP server | `src/mcp-server/server.ts` + `forge mcp serve` (exposes Forge as an MCP server consumed by Claude Desktop, Cursor, …) |
 | Orchestrator | `src/core/orchestrator.ts` |
 | Agentic loop | `src/core/loop.ts` |
 | Agents | `src/agents/{planner,architect,executor,reviewer,debugger,memory}.ts` |
@@ -547,6 +550,45 @@ cd vscode-extension && npm install && npm run build
 npx @vscode/vsce package --no-dependencies   # produces .vsix
 npx @vscode/vsce publish --no-dependencies   # marketplace
 ```
+
+### 9.2 MCP server (`forge mcp serve`)
+
+Forge can also run *as* an MCP server, not just a consumer. Other agents (Claude Desktop, Cursor, Continue, your own MCP client) register Forge once and can plan or run tasks through their own chat surfaces.
+
+```mermaid
+flowchart LR
+  classDef ag   fill:#0f172a,stroke:#38bdf8,color:#f1f5f9,rx:4,ry:4
+  classDef srv  fill:#082f49,stroke:#38bdf8,color:#e0f2fe,rx:4,ry:4
+  classDef core fill:#0c4a6e,stroke:#22d3ee,color:#cffafe,rx:4,ry:4
+  classDef d    fill:#18181b,stroke:#f59e0b,color:#fef3c7,rx:4,ry:4
+
+  CD["Claude Desktop / Cursor / Continue"]:::ag
+  MCP["forge mcp serve<br/>(stdio JSON-RPC)"]:::srv
+  ORCH["src/core/orchestrator.ts"]:::core
+  IDX[("~/.forge/global/index.db")]:::d
+  TASKS[("project/.forge/tasks/*.json")]:::d
+
+  CD <-- "tools/list · tools/call" --> MCP
+  MCP -- "forge_plan · forge_run" --> ORCH
+  MCP -- "forge_get_task · forge_list_tasks" --> IDX
+  MCP -- "forge_get_task" --> TASKS
+  ORCH -- "writes" --> TASKS
+  ORCH -- "writes" --> IDX
+```
+
+Two trust tiers:
+
+- **Read-only** (default): `forge_status`, `forge_plan`, `forge_get_task`, `forge_list_tasks`. Never writes a file. Safe to expose to any agent.
+- **Execute** (opt-in via `--allow-execute` or `FORGE_MCP_ALLOW_EXECUTE=true`): adds `forge_run` and `forge_cancel_task`. The calling agent can edit files and run shell commands inside the working directory.
+
+Implementation lives in `src/mcp-server/server.ts`. The server uses the same `orchestrateRun()` entry point as the CLI / REPL / dashboard, and the same `~/.forge/global/index.db` index that powers task lookups everywhere else — so tools called through the MCP surface are byte-identical paths to tools called through `forge run`.
+
+Permission model when called from an MCP client:
+
+- Read-only tools never trigger the permission manager.
+- `forge_run` sets `skipRoutine: true`, `allowFiles: true`, `allowShell: true`, `nonInteractive: true`. Critical-risk shell commands (classified by `src/sandbox/shell.ts`) are still hard-blocked.
+
+Full reference: [`docs/MCP-SERVER.md`](MCP-SERVER.md). Includes example configurations for Claude Desktop, Cursor, and any plain MCP client.
 
 ---
 

--- a/docs/MCP-SERVER.md
+++ b/docs/MCP-SERVER.md
@@ -1,0 +1,250 @@
+# Forge as an MCP server
+
+Forge can run as a [Model Context Protocol](https://modelcontextprotocol.io) server, exposing its planner, executor, and task store as MCP tools. Other agents — Claude Desktop, Cursor, Continue, Zed, your own MCP client — register Forge once and can plan or run tasks through their own chat surfaces, with no shell round-trip and no special integration code.
+
+## What gets exposed
+
+Two tiers, by trust level.
+
+### Read-only tier (always on)
+
+| Tool | What it does | Side effects |
+|---|---|---|
+| `forge_status` | Runtime info: version, default provider, available providers, cwd. | None. |
+| `forge_plan` | Generate a plan for a task without executing. Returns the plan JSON. | None — `planOnly: true`. |
+| `forge_get_task` | Look up a task by ID. Resolves the project automatically from the global index. | None — read from `~/.forge/global/index.db` and the project's task JSON. |
+| `forge_list_tasks` | Recent tasks newest-first. Filter by `status` or `projectId`. | None. |
+
+### Execute tier (opt-in)
+
+Enabled by `--allow-execute` or `FORGE_MCP_ALLOW_EXECUTE=true`. **These tools modify your project.**
+
+| Tool | What it does | Side effects |
+|---|---|---|
+| `forge_run` | Full classify → plan → execute → verify. Permission prompts are auto-approved (`skipRoutine: true`, `allowFiles: true`, `allowShell: true`) because MCP cannot show interactive UI. | Writes files, runs shell commands, makes model calls. |
+| `forge_cancel_task` | Cancel a live task by ID. Idempotent — already-terminal tasks return their current state without retransitioning. | Updates the task's status. |
+
+## Quick start
+
+```bash
+# 1. Install Forge if you haven't
+npm install -g @hoangsonw/forge
+
+# 2. Sanity check
+forge mcp serve --help
+```
+
+## Wire it up
+
+### Claude Desktop
+
+Edit your config file:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+- Linux: `~/.config/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "forge": {
+      "command": "forge",
+      "args": ["mcp", "serve"],
+      "env": {}
+    }
+  }
+}
+```
+
+To enable execution tools as well:
+
+```json
+{
+  "mcpServers": {
+    "forge": {
+      "command": "forge",
+      "args": ["mcp", "serve", "--allow-execute"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The Forge tools appear under the 🔌 icon.
+
+### Cursor
+
+`~/.cursor/mcp.json` (or `Cmd+Shift+P → MCP: Edit Configuration`):
+
+```json
+{
+  "mcpServers": {
+    "forge": {
+      "command": "forge",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+### Any MCP client
+
+The transport is plain stdio JSON-RPC. Spawn `forge mcp serve` (or `forge mcp serve --allow-execute`) and follow the [MCP spec](https://modelcontextprotocol.io/specification).
+
+## Flags
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--allow-execute` | off | Adds `forge_run` and `forge_cancel_task`. |
+| `--cwd <path>` | `process.cwd()` | Default working directory used when a tool call doesn't specify one. |
+
+Environment variables:
+
+| Var | Effect |
+|---|---|
+| `FORGE_MCP_ALLOW_EXECUTE=true` | Same as `--allow-execute`. Useful when the MCP client doesn't let you customize args. |
+
+## Tool reference
+
+### `forge_status`
+
+```jsonc
+// input
+{}
+
+// output
+{
+  "version": "1.0.0",
+  "provider": "ollama",
+  "defaultMode": "balanced",
+  "cwd": "/Users/me/work/project",
+  "providers": [
+    { "name": "ollama", "available": true },
+    { "name": "anthropic", "available": false }
+  ],
+  "allowExecute": false
+}
+```
+
+### `forge_plan`
+
+```jsonc
+// input
+{
+  "task": "Add a /healthz endpoint and a test for it.",
+  "cwd": "/Users/me/work/project"   // optional
+}
+
+// output
+{
+  "taskId": "task_22ce1f014275",
+  "plan": { "steps": [ /* … */ ] },
+  "summary": "…",
+  "status": "planned"
+}
+```
+
+### `forge_run`  (requires `--allow-execute`)
+
+```jsonc
+// input
+{
+  "task": "Fix the failing test in src/server.test.ts.",
+  "mode": "balanced"   // optional; "balanced" or "risky"
+}
+
+// output
+{
+  "taskId": "task_…",
+  "status": "completed",
+  "success": true,
+  "summary": "Fixed.",
+  "filesChanged": ["src/server.ts"],
+  "durationMs": 18412,
+  "costUsd": 0
+}
+```
+
+### `forge_get_task`
+
+```jsonc
+// input
+{ "taskId": "task_22ce1f014275" }
+
+// output: full Task JSON (id, prompt, plan, status, result, …)
+```
+
+Resolves the project automatically — works for tasks created in any project on the host, not just `cwd`.
+
+### `forge_list_tasks`
+
+```jsonc
+// input
+{ "limit": 20, "status": "completed", "projectId": "proj_xxx" }   // all optional
+
+// output
+[
+  { "id": "task_…", "title": "…", "status": "completed", "mode": "balanced",
+    "updated_at": "2026-04-27T12:00:00Z", "attempts": 1, "project_id": "…" },
+  …
+]
+```
+
+### `forge_cancel_task`  (requires `--allow-execute`)
+
+```jsonc
+// input
+{ "taskId": "task_…" }
+
+// output
+{ "taskId": "task_…", "status": "cancelled" }
+// or, on an already-terminal task:
+{ "taskId": "task_…", "status": "completed", "alreadyTerminal": true }
+```
+
+## Permission model
+
+When called from an MCP client, Forge cannot show an interactive permission prompt. Instead:
+
+- **Read-only tools** never need permission — they don't trigger the permission manager at all.
+- **`forge_run`** sets `skipRoutine: true`, `allowFiles: true`, `allowShell: true`, `nonInteractive: true`. Critical-risk shell commands (classified by `src/sandbox/shell.ts`) are still hard-blocked.
+- **`forge_cancel_task`** is a state-machine transition, not a tool invocation, so the permission manager isn't involved.
+
+This means: enabling `--allow-execute` is a meaningful trust decision. The calling agent is allowed to write files and run shell commands inside whatever directory you set as `--cwd` (or wherever Forge was launched from). Pair it with sandboxing if the calling agent isn't fully trusted.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  classDef ag   fill:#0f172a,stroke:#38bdf8,color:#f1f5f9,rx:4,ry:4
+  classDef srv  fill:#082f49,stroke:#38bdf8,color:#e0f2fe,rx:4,ry:4
+  classDef core fill:#0c4a6e,stroke:#22d3ee,color:#cffafe,rx:4,ry:4
+  classDef d    fill:#18181b,stroke:#f59e0b,color:#fef3c7,rx:4,ry:4
+
+  CD["Claude Desktop / Cursor / Continue"]:::ag
+  MCP["forge mcp serve<br/>(stdio JSON-RPC)"]:::srv
+  ORCH["src/core/orchestrator.ts"]:::core
+  IDX[("~/.forge/global/index.db")]:::d
+  TASKS[("project/.forge/tasks/*.json")]:::d
+
+  CD <-- "tools/list · tools/call" --> MCP
+  MCP -- "forge_plan · forge_run" --> ORCH
+  MCP -- "forge_get_task · forge_list_tasks" --> IDX
+  MCP -- "forge_get_task" --> TASKS
+  ORCH -- "writes" --> TASKS
+  ORCH -- "writes" --> IDX
+```
+
+The MCP server is a thin shim — it doesn't reimplement orchestration, it calls the same `orchestrateRun()` that the CLI / REPL / dashboard use, and it reads from the same SQLite index that powers the dashboard's task list. So a plan generated through Claude Desktop and a plan generated through `forge run` are byte-identical paths.
+
+## Troubleshooting
+
+- **`forge: command not found`** — confirm `forge` is on your PATH (`which forge`). If you installed it via nvm, the MCP client may need an absolute path: `"command": "/Users/you/.nvm/versions/node/v20.x/bin/forge"`.
+- **Tools don't appear in Claude Desktop** — check the Claude logs (`~/Library/Logs/Claude/`) for MCP connection errors. The most common cause is a typo in the JSON config.
+- **`forge_run` not exposed** — you forgot `--allow-execute` (or `FORGE_MCP_ALLOW_EXECUTE=true`). Read-only is the default for safety.
+- **Cross-project task lookups fail** — make sure the projects you want to access have been opened by `forge` at least once so they're indexed in `~/.forge/global/index.db`.
+
+## Related
+
+- [`docs/ARCHITECTURE.md` §9.2](ARCHITECTURE.md) — where the MCP server fits in the surface map.
+- [`vscode-extension/README.md`](../vscode-extension/README.md) — the in-editor surface, complementary to the MCP server.
+- [`actions/forge-run/README.md`](../../actions/forge-run/README.md) — the GitHub Action surface.

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -15,7 +15,25 @@ import { McpHttpClient } from '../../mcp/http-transport';
 import { authorize, ensureAccessToken, OAuthConfig, loadTokens } from '../../mcp/oauth';
 import { setSecret, getSecret } from '../../keychain';
 
-export const mcpCommand = new Command('mcp').description('MCP connection management.');
+export const mcpCommand = new Command('mcp').description(
+  'MCP connection management. Also `forge mcp serve` to expose Forge itself as an MCP server.',
+);
+
+mcpCommand
+  .command('serve')
+  .description(
+    'Run Forge as an MCP server on stdio. Other agents (Claude Desktop, Cursor, Continue, …) can register this and call forge_plan / forge_run / forge_get_task / forge_list_tasks / forge_status. Read-only by default; pass --allow-execute or set FORGE_MCP_ALLOW_EXECUTE=true to enable forge_run and forge_cancel_task.',
+  )
+  .option('--allow-execute', 'enable execution tools (forge_run, forge_cancel_task)', false)
+  .option('--cwd <path>', 'default working directory for tool calls')
+  .action(async (opts: { allowExecute?: boolean; cwd?: string }) => {
+    bootstrap();
+    const { runForgeMcpServerOnStdio } = await import('../../mcp-server/server');
+    await runForgeMcpServerOnStdio({
+      allowExecute: opts.allowExecute,
+      defaultCwd: opts.cwd,
+    });
+  });
 
 mcpCommand
   .command('list')

--- a/src/mcp-server/server.ts
+++ b/src/mcp-server/server.ts
@@ -1,0 +1,272 @@
+/**
+ * Forge as an MCP server. Exposes the runtime as MCP tools so other
+ * agents (Claude Desktop, Cursor, Continue, etc.) can plan and run
+ * Forge tasks through their own chat surfaces.
+ *
+ * Two trust tiers:
+ *   - read-only (default): forge_status, forge_plan, forge_get_task,
+ *     forge_list_tasks. Never writes a file.
+ *   - execute (opt-in via FORGE_MCP_ALLOW_EXECUTE=true or --allow-execute):
+ *     adds forge_run and forge_cancel_task. These can edit the project.
+ *
+ * Tools are exposed as `forge_*` namespaced functions because the MCP
+ * client typically flattens every connected server's tools into one list.
+ *
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod/v3';
+
+import { orchestrateRun } from '../core/orchestrator';
+import { loadGlobalConfig } from '../config/loader';
+import { listTasks, getTask, listProjects, type TaskIndexRow } from '../persistence/index-db';
+import { loadTask } from '../persistence/tasks';
+import { transitionTask } from '../persistence/tasks';
+import { listProviders } from '../models/provider';
+import { findProjectRoot } from '../config/loader';
+import { log } from '../logging/logger';
+import { Mode } from '../types';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PKG_VERSION = (() => {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf8'))
+      .version as string;
+  } catch {
+    return 'unknown';
+  }
+})();
+
+export interface McpServerOptions {
+  /** Enable execution tools (forge_run, forge_cancel_task). */
+  allowExecute?: boolean;
+  /** Default cwd if a tool call doesn't specify one. */
+  defaultCwd?: string;
+}
+
+export const createForgeMcpServer = (opts: McpServerOptions = {}): McpServer => {
+  const allowExecute = opts.allowExecute ?? process.env.FORGE_MCP_ALLOW_EXECUTE === 'true';
+  const defaultCwd = opts.defaultCwd ?? process.cwd();
+
+  const server = new McpServer({
+    name: 'forge',
+    version: PKG_VERSION,
+  });
+
+  const text = (s: string) => ({ content: [{ type: 'text' as const, text: s }] });
+  const json = (v: unknown) => text(typeof v === 'string' ? v : JSON.stringify(v, null, 2));
+  const err = (msg: string) => ({
+    isError: true,
+    content: [{ type: 'text' as const, text: `forge: ${msg}` }],
+  });
+
+  // ---------------- Read-only tools (always enabled) ----------------
+
+  server.registerTool(
+    'forge_status',
+    {
+      description:
+        'Get the Forge runtime status: version, default provider, default mode, available providers, and current working directory. No side effects.',
+      inputSchema: {},
+    },
+    async () => {
+      const cfg = loadGlobalConfig();
+      const providers = await Promise.all(
+        listProviders().map(async (p) => ({
+          name: p.name,
+          available: await p.isAvailable().catch(() => false),
+        })),
+      );
+      return json({
+        version: PKG_VERSION,
+        provider: cfg.provider,
+        defaultMode: cfg.defaultMode,
+        cwd: defaultCwd,
+        providers,
+        allowExecute,
+      });
+    },
+  );
+
+  server.registerTool(
+    'forge_plan',
+    {
+      description:
+        'Generate a plan for a task without executing it. Read-only — no files are modified. Returns the plan JSON (steps, dependencies, risk classification).',
+      inputSchema: {
+        task: z.string().min(1).describe('Plain-language description of what Forge should plan.'),
+        cwd: z.string().optional().describe('Working directory. Defaults to the server cwd.'),
+      },
+    },
+    async ({ task, cwd }) => {
+      try {
+        const result = await orchestrateRun({
+          input: task,
+          mode: 'plan' as Mode,
+          planOnly: true,
+          autoApprove: true,
+          cwd: cwd ?? defaultCwd,
+        });
+        return json({
+          taskId: result.task.id,
+          plan: result.task.plan ?? null,
+          summary: result.result?.summary ?? '',
+          status: result.task.status,
+        });
+      } catch (e) {
+        log.warn('forge_plan failed', { err: String(e) });
+        return err(`plan failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'forge_get_task',
+    {
+      description:
+        'Look up a task by ID. Resolves the project automatically via the global index. Returns full task JSON: prompt, plan, status, result, files changed.',
+      inputSchema: {
+        taskId: z.string().min(1).describe('The task ID, e.g. task_22ce1f014275.'),
+      },
+    },
+    async ({ taskId }) => {
+      const indexed = getTask(taskId);
+      if (!indexed) return err(`task not found: ${taskId}`);
+      const proj = listProjects().find((p) => p.id === indexed.project_id);
+      const candidates = [proj?.path, findProjectRoot(defaultCwd) ?? null, defaultCwd].filter(
+        (x): x is string => Boolean(x),
+      );
+      for (const root of candidates) {
+        const t = loadTask(root, taskId);
+        if (t) return json(t);
+      }
+      return err(`task index entry exists but file not found in ${candidates.join(', ')}`);
+    },
+  );
+
+  server.registerTool(
+    'forge_list_tasks',
+    {
+      description:
+        'List recent tasks across all projects, newest first. Optional filter by status (running, completed, failed, …) and project id.',
+      inputSchema: {
+        limit: z.number().int().min(1).max(200).optional().default(20),
+        status: z.string().optional(),
+        projectId: z.string().optional(),
+      },
+    },
+    async ({ limit, status, projectId }) => {
+      let rows: TaskIndexRow[] = listTasks(projectId, limit ?? 20);
+      if (status) rows = rows.filter((r) => r.status === status);
+      return json(
+        rows.map((r) => ({
+          id: r.id,
+          title: r.title,
+          status: r.status,
+          mode: r.mode,
+          updated_at: r.updated_at,
+          attempts: r.attempts,
+          project_id: r.project_id,
+        })),
+      );
+    },
+  );
+
+  // ---------------- Execute tools (opt-in) ----------------
+
+  if (allowExecute) {
+    server.registerTool(
+      'forge_run',
+      {
+        description:
+          'Run a task end-to-end: classify → plan → execute → verify. Will modify files. Permission prompts are auto-approved because MCP cannot show interactive UI.',
+        inputSchema: {
+          task: z.string().min(1).describe('Plain-language task description.'),
+          cwd: z.string().optional(),
+          mode: z
+            .enum(['balanced', 'risky'])
+            .optional()
+            .describe('Execution mode. Defaults to balanced.'),
+        },
+      },
+      async ({ task, cwd, mode }) => {
+        try {
+          const result = await orchestrateRun({
+            input: task,
+            mode: (mode ?? 'balanced') as Mode,
+            autoApprove: true,
+            cwd: cwd ?? defaultCwd,
+            flags: {
+              skipRoutine: true,
+              allowFiles: true,
+              allowShell: true,
+              nonInteractive: true,
+            },
+          });
+          return json({
+            taskId: result.task.id,
+            status: result.task.status,
+            success: result.result?.success !== false,
+            summary: result.result?.summary ?? '',
+            filesChanged: result.result?.filesChanged ?? [],
+            durationMs: result.result?.durationMs ?? 0,
+            costUsd: result.result?.costUsd ?? 0,
+          });
+        } catch (e) {
+          log.warn('forge_run failed', { err: String(e) });
+          return err(`run failed: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      },
+    );
+
+    server.registerTool(
+      'forge_cancel_task',
+      {
+        description:
+          'Cancel a running or pending task. Idempotent — already-terminal tasks are returned as-is.',
+        inputSchema: {
+          taskId: z.string().min(1),
+        },
+      },
+      async ({ taskId }) => {
+        const indexed = getTask(taskId);
+        if (!indexed) return err(`task not found: ${taskId}`);
+        const proj = listProjects().find((p) => p.id === indexed.project_id);
+        if (!proj) return err(`project not found for task ${taskId}`);
+        // Already-terminal tasks return their current state — idempotent.
+        if (
+          indexed.status === 'completed' ||
+          indexed.status === 'cancelled' ||
+          indexed.status === 'failed'
+        ) {
+          return json({ taskId, status: indexed.status, alreadyTerminal: true });
+        }
+        try {
+          const updated = transitionTask(proj.path, taskId, 'cancelled');
+          return json({ taskId, status: updated.status });
+        } catch (e) {
+          return err(`cancel failed: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      },
+    );
+  }
+
+  return server;
+};
+
+/**
+ * Bootstraps the MCP server on stdio. Returns a promise that resolves
+ * when the transport is closed by the peer.
+ */
+export const runForgeMcpServerOnStdio = async (opts: McpServerOptions = {}): Promise<void> => {
+  const server = createForgeMcpServer(opts);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // Keep the process alive until the transport closes.
+  await new Promise<void>((resolve) => {
+    transport.onclose = () => resolve();
+  });
+};

--- a/test/unit/mcp-server.test.ts
+++ b/test/unit/mcp-server.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Forge-as-MCP-server unit tests.
+ *
+ * Boots the server in-memory (no stdio), drives `tools/list` and
+ * `tools/call` through an in-process Transport pair, asserts on the
+ * structured responses. Covers:
+ *   • read-only mode exposes 4 tools (no forge_run / forge_cancel_task)
+ *   • --allow-execute exposes all 6 tools
+ *   • forge_status returns version + providers + cwd
+ *   • forge_list_tasks supports the limit + status filters
+ *   • forge_get_task surfaces a not-found error for unknown ids
+ *   • forge_cancel_task is idempotent on already-terminal tasks
+ *
+ * @author Son Nguyen <hoangson091104@gmail.com>
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// --- Stub orchestrator so plan/run don't actually invoke a model ---
+vi.mock('../../src/core/orchestrator', () => ({
+  orchestrateRun: vi.fn(async (params: { input: string }) => ({
+    task: {
+      id: 'task_test_abc123',
+      status: 'completed',
+      plan: { steps: [{ description: `would handle: ${params.input}` }] },
+    },
+    result: {
+      success: true,
+      summary: `planned: ${params.input}`,
+      filesChanged: [],
+      durationMs: 12,
+      costUsd: 0,
+    },
+  })),
+}));
+
+vi.mock('../../src/persistence/index-db', () => ({
+  listTasks: vi.fn(() => [
+    {
+      id: 'task_a',
+      title: 'first',
+      status: 'completed',
+      mode: 'plan',
+      project_id: 'proj-1',
+      updated_at: '2026-04-27T10:00:00Z',
+      attempts: 1,
+    },
+    {
+      id: 'task_b',
+      title: 'second',
+      status: 'running',
+      mode: 'balanced',
+      project_id: 'proj-1',
+      updated_at: '2026-04-27T11:00:00Z',
+      attempts: 1,
+    },
+    {
+      id: 'task_c',
+      title: 'third',
+      status: 'failed',
+      mode: 'balanced',
+      project_id: 'proj-2',
+      updated_at: '2026-04-27T12:00:00Z',
+      attempts: 2,
+    },
+  ]),
+  getTask: vi.fn((id: string) => {
+    if (id === 'task_known')
+      return {
+        id: 'task_known',
+        title: 't',
+        status: 'running',
+        mode: 'plan',
+        project_id: 'proj-1',
+        updated_at: '2026-04-27T10:00:00Z',
+        attempts: 1,
+      };
+    if (id === 'task_terminal')
+      return {
+        id: 'task_terminal',
+        title: 't',
+        status: 'completed',
+        mode: 'plan',
+        project_id: 'proj-1',
+        updated_at: '2026-04-27T10:00:00Z',
+        attempts: 1,
+      };
+    return null;
+  }),
+  listProjects: vi.fn(() => [
+    { id: 'proj-1', path: '/tmp/p', name: 'p', created_at: '', last_opened: '' },
+  ]),
+}));
+
+vi.mock('../../src/persistence/tasks', () => ({
+  loadTask: vi.fn((_root: string, id: string) =>
+    id === 'task_known' ? { id, title: 't', status: 'running', plan: null, result: null } : null,
+  ),
+  transitionTask: vi.fn(() => ({
+    id: 'task_known',
+    title: 't',
+    status: 'cancelled',
+  })),
+}));
+
+vi.mock('../../src/models/provider', () => ({
+  listProviders: vi.fn(() => [
+    { name: 'ollama', isAvailable: vi.fn(async () => true) },
+    { name: 'anthropic', isAvailable: vi.fn(async () => false) },
+  ]),
+}));
+
+vi.mock('../../src/config/loader', () => ({
+  loadGlobalConfig: vi.fn(() => ({ provider: 'ollama', defaultMode: 'balanced' })),
+  findProjectRoot: vi.fn(() => '/tmp/p'),
+}));
+
+import { createForgeMcpServer } from '../../src/mcp-server/server';
+
+interface RpcMessage {
+  jsonrpc: '2.0';
+  id?: number | string;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+/**
+ * Loopback transport — implements just enough of the Transport interface
+ * for the SDK to drive a session in-memory. The "client" calls
+ * `inject(...)` to push a message into the server, the server's responses
+ * land in `outbox`.
+ */
+class Loopback extends EventEmitter {
+  outbox: RpcMessage[] = [];
+  onmessage?: (msg: RpcMessage) => void;
+  onclose?: () => void;
+  onerror?: (e: Error) => void;
+  async start() {
+    /* no-op */
+  }
+  async close() {
+    this.onclose?.();
+  }
+  async send(msg: RpcMessage) {
+    this.outbox.push(msg);
+  }
+  inject(msg: RpcMessage) {
+    this.onmessage?.(msg);
+  }
+  /** Drain outbox and return any messages emitted so far. */
+  flush(): RpcMessage[] {
+    const m = this.outbox;
+    this.outbox = [];
+    return m;
+  }
+  /** Wait one microtask flush — most server handlers resolve in a single tick. */
+  async tick() {
+    await new Promise((r) => setImmediate(r));
+  }
+}
+
+const start = async (allowExecute: boolean) => {
+  const server = createForgeMcpServer({ allowExecute, defaultCwd: '/tmp/p' });
+  const transport = new Loopback();
+  await server.connect(transport);
+  // Initialize handshake so tool calls are accepted.
+  transport.inject({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 't', version: '1' },
+    },
+  });
+  await transport.tick();
+  transport.inject({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  await transport.tick();
+  transport.flush();
+  return { server, transport };
+};
+
+const callTool = async (
+  transport: Loopback,
+  name: string,
+  args: Record<string, unknown> = {},
+  id = 100,
+) => {
+  transport.inject({ jsonrpc: '2.0', id, method: 'tools/call', params: { name, arguments: args } });
+  // The server may need a couple of ticks to resolve async tool callbacks.
+  for (let i = 0; i < 5; i++) await transport.tick();
+  const reply = transport.flush().find((m) => m.id === id);
+  if (!reply) throw new Error(`no reply for ${name}`);
+  return reply;
+};
+
+const listTools = async (transport: Loopback, id = 50) => {
+  transport.inject({ jsonrpc: '2.0', id, method: 'tools/list' });
+  await transport.tick();
+  const reply = transport.flush().find((m) => m.id === id);
+  return reply!.result as { tools: Array<{ name: string }> };
+};
+
+describe('forge as MCP server', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('exposes 4 read-only tools by default', async () => {
+    const { transport } = await start(false);
+    const { tools } = await listTools(transport);
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      'forge_get_task',
+      'forge_list_tasks',
+      'forge_plan',
+      'forge_status',
+    ]);
+  });
+
+  it('exposes 6 tools when execute is allowed', async () => {
+    const { transport } = await start(true);
+    const { tools } = await listTools(transport);
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      'forge_cancel_task',
+      'forge_get_task',
+      'forge_list_tasks',
+      'forge_plan',
+      'forge_run',
+      'forge_status',
+    ]);
+  });
+
+  it('forge_status returns version, provider, and provider availability', async () => {
+    const { transport } = await start(false);
+    const reply = await callTool(transport, 'forge_status');
+    const text = (reply.result as { content: { text: string }[] }).content[0].text;
+    const body = JSON.parse(text);
+    expect(body.provider).toBe('ollama');
+    expect(body.cwd).toBe('/tmp/p');
+    expect(body.providers).toEqual([
+      { name: 'ollama', available: true },
+      { name: 'anthropic', available: false },
+    ]);
+    expect(body.allowExecute).toBe(false);
+  });
+
+  it('forge_list_tasks honors the status filter', async () => {
+    const { transport } = await start(false);
+    const reply = await callTool(transport, 'forge_list_tasks', { status: 'running' });
+    const body = JSON.parse((reply.result as { content: { text: string }[] }).content[0].text);
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe('task_b');
+  });
+
+  it('forge_get_task returns the loaded task body for a known id', async () => {
+    const { transport } = await start(false);
+    const reply = await callTool(transport, 'forge_get_task', { taskId: 'task_known' });
+    const body = JSON.parse((reply.result as { content: { text: string }[] }).content[0].text);
+    expect(body.id).toBe('task_known');
+    expect(body.status).toBe('running');
+  });
+
+  it('forge_get_task returns isError for an unknown id', async () => {
+    const { transport } = await start(false);
+    const reply = await callTool(transport, 'forge_get_task', { taskId: 'task_nope' });
+    const result = reply.result as { isError?: boolean; content: { text: string }[] };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('task_nope');
+  });
+
+  it('forge_plan calls the orchestrator in plan-only mode and returns the plan', async () => {
+    const orchModule = await import('../../src/core/orchestrator');
+    const { transport } = await start(false);
+    const reply = await callTool(transport, 'forge_plan', { task: 'add /healthz' });
+    const body = JSON.parse((reply.result as { content: { text: string }[] }).content[0].text);
+    expect(body.taskId).toBe('task_test_abc123');
+    expect(body.plan).toEqual({ steps: [{ description: 'would handle: add /healthz' }] });
+    expect(orchModule.orchestrateRun).toHaveBeenCalledWith(
+      expect.objectContaining({ planOnly: true, mode: 'plan' }),
+    );
+  });
+
+  it('forge_cancel_task is idempotent on already-terminal tasks', async () => {
+    const tasksModule = await import('../../src/persistence/tasks');
+    const { transport } = await start(true);
+    const reply = await callTool(transport, 'forge_cancel_task', { taskId: 'task_terminal' });
+    const body = JSON.parse((reply.result as { content: { text: string }[] }).content[0].text);
+    expect(body.alreadyTerminal).toBe(true);
+    expect(body.status).toBe('completed');
+    expect(tasksModule.transitionTask).not.toHaveBeenCalled();
+  });
+
+  it('forge_cancel_task transitions live tasks to cancelled', async () => {
+    const tasksModule = await import('../../src/persistence/tasks');
+    const { transport } = await start(true);
+    const reply = await callTool(transport, 'forge_cancel_task', { taskId: 'task_known' });
+    const body = JSON.parse((reply.result as { content: { text: string }[] }).content[0].text);
+    expect(body.status).toBe('cancelled');
+    expect(tasksModule.transitionTask).toHaveBeenCalledWith('/tmp/p', 'task_known', 'cancelled');
+  });
+});


### PR DESCRIPTION
New surface that lets Claude Desktop, Cursor, Continue, and any other MCP client drive Forge's planner / executor / task store from their own chat.

Two trust tiers:
- Read-only (default): forge_status, forge_plan, forge_get_task, forge_list_tasks. Never writes a file.
- Execute (--allow-execute / FORGE_MCP_ALLOW_EXECUTE=true): adds forge_run and forge_cancel_task. Auto-approves routine permissions because MCP cannot show interactive prompts; critical-risk shell commands are still hard-blocked by the sandbox classifier.

Implementation in src/mcp-server/server.ts wraps the same orchestrateRun() that powers the CLI/REPL/dashboard, so MCP-driven plans are byte-identical paths to forge run.

Wired via 'forge mcp serve' subcommand in src/cli/commands/mcp.ts (supports --allow-execute and --cwd).

- 9 unit tests covering tool exposure (4 vs 6), forge_status payload, list-task filters, get-task not-found path, plan invocation, cancel idempotency on terminal tasks.
- docs/MCP-SERVER.md: full reference + per-client setup (Claude Desktop, Cursor, plain MCP clients).
- ARCHITECTURE.md §9.2: surface diagram + permission model.
- README.md: new pointer block in the Skills/MCP section.