### PR TITLE
chore(release): 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Forge are tracked here. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.0.1] - 2026-04-29
+
+Patch release: ships the MCP server surface (`forge mcp serve`) that landed after 1.0.0, plus a CI fix that unblocks the Windows artifacts job in the release workflow.
+
+### Added
+- **Forge as an MCP server** (`forge mcp serve`). Exposes the runtime as MCP tools so Claude Desktop, Cursor, Continue, and any other MCP client can plan and run Forge tasks from their own chat. Two trust tiers: read-only (default) exposes `forge_status`, `forge_plan`, `forge_get_task`, `forge_list_tasks`; `--allow-execute` (or `FORGE_MCP_ALLOW_EXECUTE=true`) adds `forge_run` and `forge_cancel_task`. Wraps the same `orchestrateRun()` entry point as the CLI/REPL/dashboard, so MCP-driven plans are byte-identical paths. See `docs/MCP-SERVER.md` for per-client setup.
+
+### Fixed
+- **Release workflow Windows artifacts**: the three install steps in `release.yml` used bash-only constructs (`2>/dev/null`, `||`-grouped fallbacks, `rm -rf`) which PowerShell parses as filesystem paths. Force `shell: bash` so the Windows runner uses Git Bash. The artifacts (win32-x64) job no longer crashes with `Could not find a part of the path 'D:\dev\null'`.
+
 ## [1.0.0] - 2026-04-27
 
 First stable release. The runtime, agentic loop, persistence model, permission system, sandbox, and provider abstractions are now considered stable surface area. Breaking changes from here on bump MAJOR.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -443,10 +443,10 @@ FROM ghcr.io/hoangsonw/forge-agentic-coding-cli:0.2.0
 
 ```bash
 # npm — downgrade explicitly.
-npm install -g @hoangsonw/forge@1.0.0
+npm install -g @hoangsonw/forge@1.0.1
 
 # Docker — swap the tag.
-docker pull ghcr.io/hoangsonw/forge-agentic-coding-cli:1.0.0
+docker pull ghcr.io/hoangsonw/forge-agentic-coding-cli:1.0.1
 
 # Tell the built-in updater to stop nagging about a broken version.
 forge update ignore 0.2.0
@@ -643,6 +643,20 @@ Stable within a MAJOR. Migrations under [`src/migrations/runner.ts`](src/migrati
 
 <!-- Newest at the top. Keep the template from
      "Release-notes template" above. -->
+
+### v1.0.1 — 2026-04-29
+
+#### Highlights
+- **Forge as an MCP server** (`forge mcp serve`) — Claude Desktop, Cursor, Continue, and any MCP client can now plan and run Forge tasks from their own chat. Read-only by default; opt in to execution with `--allow-execute`.
+- **Release workflow fix** — Windows artifacts job no longer crashes on `2>/dev/null` because the install steps now run under Git Bash.
+
+#### Added
+- `forge mcp serve` subcommand with `--allow-execute` and `--cwd` flags.
+- New tools: `forge_status`, `forge_plan`, `forge_get_task`, `forge_list_tasks`, `forge_run`, `forge_cancel_task`.
+- `docs/MCP-SERVER.md` with per-client (Claude Desktop, Cursor, plain MCP) setup.
+
+#### Fixed
+- `.github/workflows/release.yml` install steps now force `shell: bash` so the Windows runner stops parsing `/dev/null` as a path.
 
 ### v1.0.0 — 2026-04-27
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hoangsonw/forge",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hoangsonw/forge",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoangsonw/forge",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Forge - a local-first, multi-agent, programmable software-engineering runtime",
   "license": "MIT",
   "author": "Son Nguyen (hoangsonw)",


### PR DESCRIPTION
This pull request publishes version 1.0.1 of Forge. It introduces the MCP server feature, allowing Forge to be used as an MCP server for integration with clients like Claude Desktop, Cursor, and Continue, and fixes a release workflow issue affecting Windows artifacts. Documentation and release notes have been updated to reflect these changes.

**New features:**

* Added the MCP server surface with the `forge mcp serve` subcommand, supporting two trust tiers and enabling external MCP clients to plan and run Forge tasks. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R14) [[2]](diffhunk://#diff-4a00447b47c36ebd3ded77321deff288e424f4605496ee1199fc9953a20f4473R647-R660)
* Documented MCP server usage and per-client setup in `docs/MCP-SERVER.md`.

**Bug fixes:**

* Fixed the release workflow for Windows by forcing `shell: bash` in install steps, resolving failures due to shell syntax incompatibilities. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R14) [[2]](diffhunk://#diff-4a00447b47c36ebd3ded77321deff288e424f4605496ee1199fc9953a20f4473R647-R660)

**Release and versioning:**

* Bumped the package version to `1.0.1` in `package.json` and updated installation instructions and Docker tags in `RELEASES.md`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-4a00447b47c36ebd3ded77321deff288e424f4605496ee1199fc9953a20f4473L446-R449)
* Added detailed release notes for v1.0.1 in `CHANGELOG.md` and `RELEASES.md`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R14) [[2]](diffhunk://#diff-4a00447b47c36ebd3ded77321deff288e424f4605496ee1199fc9953a20f4473R647-R660)