### PR TITLE
feat(action): add forge-run GitHub Action for running tasks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,13 +336,24 @@ jobs:
         run: npm audit --audit-level=high || true
 
   # ---------------------------------------------------------------------
+  # 🎬  forge-run action — smoke-tests the GitHub Action's runner script
+  # ---------------------------------------------------------------------
+  action-tests:
+    name: 🎬 action tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run forge-run smoke tests
+        run: bash actions/forge-run/test/run.test.sh
+
+  # ---------------------------------------------------------------------
   # 📊  Pipeline status — runs last, always; writes job-by-job summary
   # ---------------------------------------------------------------------
   pipeline-status:
     name: 📊 pipeline status
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, lint, typecheck, test, coverage, build, docker, audit]
+    needs: [format, lint, typecheck, test, coverage, build, docker, audit, action-tests]
     steps:
       - name: Write GitHub summary
         env:
@@ -354,6 +365,7 @@ jobs:
           BUILD_R:    ${{ needs.build.result }}
           DOCKER_R:   ${{ needs.docker.result }}
           AUDIT_R:    ${{ needs.audit.result }}
+          ACTION_R:   ${{ needs.action-tests.result }}
         run: |
           set -eu
           icon() {
@@ -378,6 +390,7 @@ jobs:
             printf "| 🏗️ build         | %s  \`%s\` |\n" "$(icon "$BUILD_R")"  "$BUILD_R"
             printf "| 🐳 docker-build  | %s  \`%s\` |\n" "$(icon "$DOCKER_R")" "$DOCKER_R"
             printf "| 🔐 audit         | %s  \`%s\` |\n" "$(icon "$AUDIT_R")"  "$AUDIT_R"
+            printf "| 🎬 action tests  | %s  \`%s\` |\n" "$(icon "$ACTION_R")" "$ACTION_R"
             echo ""
             echo "> Commit: \`${GITHUB_SHA:0:7}\` · Ref: \`${GITHUB_REF_NAME}\` · Run: [#${GITHUB_RUN_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -390,10 +403,11 @@ jobs:
           TEST_R:   ${{ needs.test.result }}
           BUILD_R:  ${{ needs.build.result }}
           DOCKER_R: ${{ needs.docker.result }}
+          ACTION_R: ${{ needs.action-tests.result }}
         run: |
           set -eu
           bad=0
-          for v in "$FORMAT_R" "$LINT_R" "$TYPE_R" "$TEST_R" "$BUILD_R" "$DOCKER_R"; do
+          for v in "$FORMAT_R" "$LINT_R" "$TYPE_R" "$TEST_R" "$BUILD_R" "$DOCKER_R" "$ACTION_R"; do
             if [ "$v" != "success" ] && [ "$v" != "skipped" ]; then
               bad=1
             fi

--- a/README.md
+++ b/README.md
@@ -834,8 +834,23 @@ flowchart LR
   TYPE --> BUILD["🏗️ build"]:::pass
   BUILD --> DOCKER["🐳 docker-build"]:::pass
   PR --> AUDIT["🔐 audit"]:::pass
-  FMT & LINT & TYPE & TEST & BUILD & DOCKER & AUDIT & COV --> STATUS["📊 pipeline status<br/>GH step summary · fails if any required job failed"]:::gate
+  PR --> ACT["🎬 action tests"]:::pass
+  FMT & LINT & TYPE & TEST & BUILD & DOCKER & AUDIT & COV & ACT --> STATUS["📊 pipeline status<br/>GH step summary · fails if any required job failed"]:::gate
 ```
+
+### GitHub Action
+
+The repo also ships its own GitHub Action under [`actions/forge-run/`](actions/forge-run). Drop it into any workflow to run a Forge task in CI — plan-only previews on every PR, full execution + verification on demand, results posted as a PR comment:
+
+```yaml
+- uses: hoangsonww/Forge-Agentic-Coding-CLI/actions/forge-run@v1
+  with:
+    task: "Audit this PR for missing tests."
+    mode: plan
+    comment: true
+```
+
+See [`actions/forge-run/README.md`](actions/forge-run/README.md) for the full input/output reference and example workflows.
 
 ### Release (on `v*` tag)
 

--- a/actions/forge-run/README.md
+++ b/actions/forge-run/README.md
@@ -1,0 +1,163 @@
+# forge-run — GitHub Action
+
+Run [Forge](https://github.com/hoangsonww/Forge-Agentic-Coding-CLI) agentic coding tasks inside any GitHub Actions workflow. Plan-only previews on every PR, full execution + verification on demand, results posted as a PR comment.
+
+## Quick start
+
+```yaml
+# .github/workflows/forge-plan.yml
+name: forge plan
+on: [pull_request]
+jobs:
+  forge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hoangsonww/Forge-Agentic-Coding-CLI/actions/forge-run@v1
+        with:
+          task: "Audit this PR for missing tests and propose a plan to add them."
+          mode: plan
+          comment: true
+```
+
+## Inputs
+
+| Input | Default | Purpose |
+|---|---|---|
+| `task` | (required) | Task description for Forge. Multi-line allowed. |
+| `mode` | `plan` | `plan` (read-only, safe), `balanced` (executes), `risky` (no permission prompts). |
+| `extra-args` | `''` | Extra flags forwarded to `forge run`, e.g. `--max-steps 30`. |
+| `forge-version` | `latest` | Pin a specific runtime version for reproducibility. |
+| `node-version` | `20` | Node version for the install step. |
+| `working-directory` | `.` | Where to run the task. |
+| `provider` | `''` | Override provider (`anthropic`, `openai`, `ollama`, …). Empty = runtime default. |
+| `comment` | `false` | Post the result as a PR comment when the trigger is `pull_request`. |
+| `fail-on-error` | `true` | Whether to fail the workflow when Forge exits non-zero. |
+| `cache-forge-home` | `true` | Cache `~/.forge` between runs to keep the SQLite index warm. |
+
+## Outputs
+
+| Output | Example | Notes |
+|---|---|---|
+| `success` | `true` | `false` if Forge exited non-zero. |
+| `task-id` | `task_22ce1f014275` | Forge task ID. |
+| `summary` | `Added /healthz and a test` | One-line summary. Multi-line via heredoc-encoded output. |
+| `files-changed` | `src/a.ts test/a.test.ts` | Space-separated list. |
+| `duration-ms` | `12345` | Wall-clock duration. |
+| `cost-usd` | `0.0000` | Estimated cost (zero for local providers). |
+| `log-path` | `/tmp/forge-action/run.log` | Full log file on the runner. |
+
+## Examples
+
+### Plan-only preview on every PR
+
+```yaml
+name: forge plan
+on: [pull_request]
+jobs:
+  forge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hoangsonww/Forge-Agentic-Coding-CLI/actions/forge-run@v1
+        with:
+          task: |
+            Read the PR diff. Identify any files that gained behavior
+            without test coverage. Output a plan with one task per gap.
+          mode: plan
+          comment: true
+```
+
+### Auto-fix lint warnings on demand
+
+Triggered manually via `Run workflow`:
+
+```yaml
+name: forge fix
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: 'What should Forge do?'
+        required: true
+jobs:
+  forge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hoangsonww/Forge-Agentic-Coding-CLI/actions/forge-run@v1
+        id: forge
+        with:
+          task: ${{ inputs.task }}
+          mode: balanced
+          extra-args: "--max-steps 60"
+      - name: Open PR with changes
+        if: steps.forge.outputs.success == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'forge: ${{ inputs.task }}'
+          branch: forge/${{ steps.forge.outputs.task-id }}
+          title: '🤖 ${{ steps.forge.outputs.summary }}'
+          body: |
+            Forge task `${{ steps.forge.outputs.task-id }}` completed in ${{ steps.forge.outputs.duration-ms }} ms.
+
+            **Files changed:** `${{ steps.forge.outputs.files-changed }}`
+```
+
+### Pin to a specific Forge version
+
+```yaml
+- uses: hoangsonww/Forge-Agentic-Coding-CLI/actions/forge-run@v1
+  with:
+    forge-version: '1.0.0'
+    task: '…'
+```
+
+### Use Anthropic instead of the default provider
+
+```yaml
+- uses: hoangsonww/Forge-Agentic-Coding-CLI/actions/forge-run@v1
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  with:
+    provider: anthropic
+    task: '…'
+```
+
+## Modes
+
+| Mode | What it does | When to use |
+|---|---|---|
+| `plan` | Generates a plan, never writes a file. Permissions and risky tools are off. | Default for any PR check. Cannot break anything. |
+| `balanced` | Full classify → plan → execute → verify pipeline. Permission prompts are auto-approved (`--skip-permissions` is on). | When you trust the task and want it to land. |
+| `risky` | Same as balanced. Reserved for future capabilities that need a higher trust level. | Advanced flows. |
+
+## Behaviour notes
+
+- **Caching**: `~/.forge` is cached by default. The cache key is keyed on `runner.os + forge-version + repo`, so two repos using the same runner don't share secrets via the index DB. Disable with `cache-forge-home: false`.
+- **Outputs are GitHub-Action standard**: single-line outputs go straight into `$GITHUB_OUTPUT`; the `summary` field uses the heredoc form because it can be multi-line. Read it with `${{ steps.<id>.outputs.summary }}`.
+- **PR comments** are only posted when both `comment: true` and the workflow event is `pull_request`. The action skips silently in any other event.
+- **Job summary**: every run writes a markdown table to `$GITHUB_STEP_SUMMARY` so the result shows up in the Actions UI tab.
+
+## Security
+
+- Forge runs inside the runner's normal sandbox. Tasks in `plan` mode are read-only.
+- The action does not exfiltrate any data. All processing happens on your runner.
+- Pin `forge-version` if you want reproducible runs across CI; `latest` follows the npm `latest` tag.
+- If you set `provider: anthropic` or `provider: openai`, supply the corresponding API key via `secrets.*` and `env:` — the action does not touch your secrets.
+
+## Testing
+
+```bash
+cd actions/forge-run
+bash test/run.test.sh
+```
+
+The test stubs `forge` and asserts that the runner script parses the completion block, writes the right outputs, and respects `fail-on-error`. Runs in a few hundred ms.
+
+## License
+
+MIT — same as the parent project.

--- a/actions/forge-run/action.yml
+++ b/actions/forge-run/action.yml
@@ -1,0 +1,136 @@
+name: 'Forge — Agentic Coding Run'
+description: 'Run a Forge agentic coding task in CI. Supports plan-only previews, full execution with verification, and PR-comment reporting.'
+author: 'Son Nguyen <hoangson091104@gmail.com>'
+branding:
+  icon: 'cpu'
+  color: 'blue'
+
+inputs:
+  task:
+    description: 'The task description that Forge should plan or execute. Multi-line is allowed.'
+    required: true
+  mode:
+    description: 'Execution mode: plan, balanced, risky. Defaults to plan, which is read-only and safe for any branch.'
+    required: false
+    default: 'plan'
+  extra-args:
+    description: 'Additional CLI flags forwarded to `forge run`, e.g. "--max-steps 30 --no-tests".'
+    required: false
+    default: ''
+  forge-version:
+    description: 'Pinned Forge version on npm. Defaults to latest. Use a full version like 1.0.0 for reproducible runs.'
+    required: false
+    default: 'latest'
+  node-version:
+    description: 'Node.js version used to install the Forge runtime.'
+    required: false
+    default: '20'
+  working-directory:
+    description: 'Directory the task runs in. Defaults to the repository root.'
+    required: false
+    default: '.'
+  provider:
+    description: 'Force a specific Forge provider (anthropic | openai | ollama | …). Empty = use the runtime default.'
+    required: false
+    default: ''
+  comment:
+    description: 'When true and the workflow is triggered by a PR event, post the task result as a PR comment.'
+    required: false
+    default: 'false'
+  fail-on-error:
+    description: 'When true, mark the action as failed if Forge exits non-zero. When false, surface the failure in outputs but keep the workflow green.'
+    required: false
+    default: 'true'
+  cache-forge-home:
+    description: 'When true, cache ~/.forge across runs to speed up the SQLite index and skill installs.'
+    required: false
+    default: 'true'
+
+outputs:
+  success:
+    description: 'true if Forge completed successfully, false otherwise.'
+    value: ${{ steps.run.outputs.success }}
+  task-id:
+    description: 'The Forge task ID assigned to this run.'
+    value: ${{ steps.run.outputs.task-id }}
+  summary:
+    description: 'Forge''s summary of what changed (one line).'
+    value: ${{ steps.run.outputs.summary }}
+  files-changed:
+    description: 'Space-separated list of files Forge modified.'
+    value: ${{ steps.run.outputs.files-changed }}
+  duration-ms:
+    description: 'How long the run took, in milliseconds.'
+    value: ${{ steps.run.outputs.duration-ms }}
+  cost-usd:
+    description: 'Estimated USD cost of the run (zero for local providers).'
+    value: ${{ steps.run.outputs.cost-usd }}
+  log-path:
+    description: 'Absolute path to the captured Forge log file on the runner.'
+    value: ${{ steps.run.outputs.log-path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Cache ~/.forge
+      if: inputs.cache-forge-home == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/.forge
+        key: forge-home-${{ runner.os }}-${{ inputs.forge-version }}-${{ github.repository }}
+        restore-keys: |
+          forge-home-${{ runner.os }}-${{ inputs.forge-version }}-
+          forge-home-${{ runner.os }}-
+
+    - name: Install Forge
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ "${{ inputs.forge-version }}" = "latest" ]; then
+          npm install -g @hoangsonw/forge
+        else
+          npm install -g @hoangsonw/forge@${{ inputs.forge-version }}
+        fi
+        forge --version
+
+    - name: Configure provider
+      if: inputs.provider != ''
+      shell: bash
+      run: forge config set provider ${{ inputs.provider }}
+
+    - name: Run Forge
+      id: run
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        FORGE_TASK: ${{ inputs.task }}
+        FORGE_MODE: ${{ inputs.mode }}
+        FORGE_EXTRA_ARGS: ${{ inputs.extra-args }}
+        FORGE_FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+      run: |
+        bash "${{ github.action_path }}/scripts/run.sh"
+
+    - name: Post PR comment
+      if: inputs.comment == 'true' && github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const path = process.env.FORGE_COMMENT_PATH;
+          if (!path || !fs.existsSync(path)) {
+            core.warning(`No comment payload at ${path}; skipping.`);
+            return;
+          }
+          const body = fs.readFileSync(path, 'utf8');
+          await github.rest.issues.createComment({
+            ...context.repo,
+            issue_number: context.issue.number,
+            body,
+          });
+      env:
+        FORGE_COMMENT_PATH: ${{ steps.run.outputs.comment-path }}

--- a/actions/forge-run/scripts/run.sh
+++ b/actions/forge-run/scripts/run.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Forge GitHub Action — task runner
+#
+# Spawns `forge run`, captures stdout to a log, parses key fields out of the
+# completion block (task id, summary, files changed, duration, cost), and
+# emits them as GitHub Actions outputs. Also prepares a markdown comment
+# payload that the action.yml composite step uses for `actions/github-script`.
+# -----------------------------------------------------------------------------
+set -uo pipefail
+
+# Output sinks. GITHUB_OUTPUT is provided by the runner; fall back to a temp
+# file when invoked locally for testing.
+GH_OUTPUT="${GITHUB_OUTPUT:-/tmp/forge-action-outputs.txt}"
+GH_SUMMARY="${GITHUB_STEP_SUMMARY:-/tmp/forge-action-summary.md}"
+
+# Mode → forge args. `plan` is the safe default (no writes); `balanced` and
+# `risky` enable execution. We always pass `--yes` so the agent never blocks
+# on a prompt in CI.
+case "${FORGE_MODE:-plan}" in
+  plan)     mode_args=(--mode plan --yes);;
+  balanced) mode_args=(--mode balanced --yes --skip-permissions);;
+  risky)    mode_args=(--mode risky --yes --skip-permissions);;
+  *) echo "::error::Unknown mode: ${FORGE_MODE}. Use plan|balanced|risky."; exit 2;;
+esac
+
+# Extra args from the caller — split on whitespace, no quoting tricks.
+read -r -a extra_args <<< "${FORGE_EXTRA_ARGS:-}"
+
+log_dir="${RUNNER_TEMP:-/tmp}/forge-action"
+mkdir -p "$log_dir"
+log_file="$log_dir/run.log"
+comment_file="$log_dir/comment.md"
+
+echo "::group::forge run"
+echo "task: ${FORGE_TASK}"
+echo "mode: ${FORGE_MODE:-plan}"
+echo "extra: ${FORGE_EXTRA_ARGS:-(none)}"
+echo "log: ${log_file}"
+echo "::endgroup::"
+
+now_ms() {
+  perl -MTime::HiRes=time -e 'printf("%.0f", time*1000)' 2>/dev/null \
+    || python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null \
+    || echo $(($(date +%s) * 1000))
+}
+start_ms=$(now_ms)
+
+forge run "${FORGE_TASK}" "${mode_args[@]}" ${extra_args[@]+"${extra_args[@]}"} 2>&1 | tee "$log_file"
+exit_code=${PIPESTATUS[0]}
+
+end_ms=$(now_ms)
+duration=$((end_ms - start_ms))
+
+# ---------------------------------------------------------------------------
+# Parse the completion block. Forge prints lines like:
+#   ━━━ DONE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#     task     task_xxxxxxxxxxxx
+#     summary  Added /healthz and a test for it.
+#     changed  src/server.ts test/server.test.ts
+#     duration 12.3s
+#     cost     $0.0000
+# Use a set of forgiving greps so we don't break if any one line moves.
+# ---------------------------------------------------------------------------
+strip() { sed -E "s/^[[:space:]]*//; s/[[:space:]]*\$//; s/$(printf '\033')\[[0-9;]*m//g"; }
+field()  { grep -E "^[[:space:]]*${1}[[:space:]]+" "$log_file" | tail -1 | sed -E "s/^[[:space:]]*${1}[[:space:]]+//" | strip; }
+
+task_id=$(field 'task')
+summary=$(field 'summary')
+changed=$(field 'changed' | tr -s ' ' || true)
+cost=$(field 'cost' | sed 's/^\$//')
+
+# Fallback: if the completion block didn't render (e.g. plan-only mode),
+# pull the task id from the LAUNCHING block.
+if [ -z "$task_id" ]; then
+  task_id=$(grep -Eo 'task_[a-z0-9]+' "$log_file" | head -1)
+fi
+
+success="true"
+if [ "$exit_code" -ne 0 ]; then success="false"; fi
+
+# Single-line outputs only — multi-line needs the heredoc form, which we use
+# below for `summary` if it contains newlines.
+{
+  echo "success=${success}"
+  echo "task-id=${task_id}"
+  echo "files-changed=${changed}"
+  echo "duration-ms=${duration}"
+  echo "cost-usd=${cost:-0}"
+  echo "log-path=${log_file}"
+  echo "comment-path=${comment_file}"
+} >> "$GH_OUTPUT"
+
+# Multi-line summary via heredoc syntax.
+{
+  printf 'summary<<__FORGE_EOF__\n'
+  printf '%s\n' "${summary:-(no summary)}"
+  printf '__FORGE_EOF__\n'
+} >> "$GH_OUTPUT"
+
+# ---------------------------------------------------------------------------
+# Job summary — markdown that lands in the Actions UI tab.
+# ---------------------------------------------------------------------------
+{
+  if [ "$success" = "true" ]; then
+    printf '### ✅ Forge run completed\n\n'
+  else
+    printf '### ❌ Forge run failed (exit %s)\n\n' "$exit_code"
+  fi
+  printf '| Field | Value |\n|---|---|\n'
+  printf '| Task ID | `%s` |\n' "${task_id:-?}"
+  printf '| Mode | `%s` |\n' "${FORGE_MODE:-plan}"
+  printf '| Duration | %d ms |\n' "$duration"
+  printf '| Cost | $%s |\n' "${cost:-0}"
+  if [ -n "$changed" ]; then
+    printf '| Files changed | `%s` |\n' "$changed"
+  fi
+  printf '\n#### Summary\n\n%s\n' "${summary:-(no summary)}"
+} >> "$GH_SUMMARY"
+
+# ---------------------------------------------------------------------------
+# PR comment payload (action.yml conditionally posts this).
+# ---------------------------------------------------------------------------
+{
+  if [ "$success" = "true" ]; then
+    printf '### 🤖 Forge — task complete\n\n'
+  else
+    printf '### ❌ Forge — task failed\n\n'
+  fi
+  printf '> %s\n\n' "${summary:-(no summary)}"
+  printf '<details><summary>details</summary>\n\n'
+  printf '| Field | Value |\n|---|---|\n'
+  printf '| Task | `%s` |\n' "${task_id:-?}"
+  printf '| Mode | `%s` |\n' "${FORGE_MODE:-plan}"
+  printf '| Duration | %d ms |\n' "$duration"
+  printf '| Cost | $%s |\n' "${cost:-0}"
+  if [ -n "$changed" ]; then
+    printf '| Files | `%s` |\n' "$changed"
+  fi
+  printf '\n</details>\n'
+} > "$comment_file"
+
+if [ "$exit_code" -ne 0 ] && [ "${FORGE_FAIL_ON_ERROR:-true}" = "true" ]; then
+  echo "::error::forge run exited with status $exit_code"
+  exit "$exit_code"
+fi

--- a/actions/forge-run/test/run.test.sh
+++ b/actions/forge-run/test/run.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Smoke-tests for the forge-action runner. Stubs `forge` with a fake binary
+# that prints a canned completion block, drives `run.sh`, then asserts on
+# the parsed outputs and the generated comment / summary payloads.
+# -----------------------------------------------------------------------------
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+failures=0
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  ✓ %s\n' "$name"
+  else
+    printf '  ✗ %s\n      expected: %s\n      actual:   %s\n' "$name" "$expected" "$actual"
+    failures=$((failures+1))
+  fi
+}
+assert_match() {
+  local name="$1" pattern="$2" file="$3"
+  if grep -qE -- "$pattern" "$file"; then
+    printf '  ✓ %s\n' "$name"
+  else
+    printf '  ✗ %s\n      pattern not found: %s\n      in file: %s\n' "$name" "$pattern" "$file"
+    failures=$((failures+1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Stub a `forge` binary that emits a realistic LAUNCHING + DONE block.
+# ---------------------------------------------------------------------------
+TMP=$(mktemp -d)
+trap "rm -rf '$TMP'" EXIT
+
+stub_dir="$TMP/bin"
+mkdir -p "$stub_dir"
+cat > "$stub_dir/forge" <<'STUB'
+#!/usr/bin/env bash
+echo "━━━ LAUNCHING ━━━━━━━━━━━━━━━━━━"
+echo "    task task_22ce1f014275"
+echo ""
+echo "doing the thing..."
+echo "━━━ DONE ━━━━━━━━━━━━━━━━━━━━━━━"
+echo "    task     task_22ce1f014275"
+echo "    summary  Added /healthz route and a test"
+echo "    changed  src/server.ts test/server.test.ts"
+echo "    duration 12.3s"
+echo "    cost     \$0.0000"
+exit 0
+STUB
+chmod +x "$stub_dir/forge"
+
+# ---------------------------------------------------------------------------
+# Drive the script with stubbed env. Capture outputs into a writable file.
+# ---------------------------------------------------------------------------
+export PATH="$stub_dir:$PATH"
+export RUNNER_TEMP="$TMP"
+export GITHUB_OUTPUT="$TMP/outputs.txt"
+export GITHUB_STEP_SUMMARY="$TMP/summary.md"
+: > "$GITHUB_OUTPUT"
+: > "$GITHUB_STEP_SUMMARY"
+
+export FORGE_TASK="add a /healthz route"
+export FORGE_MODE="plan"
+export FORGE_EXTRA_ARGS=""
+export FORGE_FAIL_ON_ERROR="true"
+
+bash scripts/run.sh > "$TMP/stdout.log" 2>&1
+rc=$?
+
+# ---------------------------------------------------------------------------
+# Assertions.
+# ---------------------------------------------------------------------------
+echo "[1] Exits 0 on a successful forge run"
+assert_eq "exit code" "0" "$rc"
+
+echo "[2] Outputs file has the expected fields"
+assert_match "success=true"      '^success=true$'                        "$GITHUB_OUTPUT"
+assert_match "task-id is set"    '^task-id=task_22ce1f014275$'           "$GITHUB_OUTPUT"
+assert_match "files-changed"     '^files-changed=src/server.ts test/server.test.ts$' "$GITHUB_OUTPUT"
+assert_match "cost-usd parsed"   '^cost-usd=0.0000$'                     "$GITHUB_OUTPUT"
+assert_match "summary heredoc"   '^summary<<__FORGE_EOF__$'              "$GITHUB_OUTPUT"
+assert_match "summary content"   'Added /healthz route and a test'       "$GITHUB_OUTPUT"
+assert_match "duration positive" '^duration-ms=[1-9][0-9]*$'             "$GITHUB_OUTPUT"
+
+echo "[3] Job summary markdown is well-formed"
+assert_match "summary header"    '✅ Forge run completed'                "$GITHUB_STEP_SUMMARY"
+assert_match "summary task row"  '\| Task ID \| `task_22ce1f014275` \|' "$GITHUB_STEP_SUMMARY"
+
+echo "[4] Comment payload exists and is well-formed"
+comment_path=$(grep '^comment-path=' "$GITHUB_OUTPUT" | sed 's/^comment-path=//')
+[ -f "$comment_path" ] && echo "  ✓ comment file exists at $comment_path" || { echo "  ✗ comment file missing"; failures=$((failures+1)); }
+assert_match "comment header"    '🤖 Forge — task complete'             "$comment_path"
+assert_match "comment summary"   'Added /healthz route and a test'       "$comment_path"
+
+# ---------------------------------------------------------------------------
+# Failure path: stub forge with non-zero exit.
+# ---------------------------------------------------------------------------
+echo "[5] Non-zero forge exit propagates when fail-on-error=true"
+cat > "$stub_dir/forge" <<'STUB'
+#!/usr/bin/env bash
+echo "boom"
+exit 7
+STUB
+chmod +x "$stub_dir/forge"
+: > "$GITHUB_OUTPUT"
+: > "$GITHUB_STEP_SUMMARY"
+
+set +e
+bash scripts/run.sh > "$TMP/stdout.log" 2>&1
+rc=$?
+set -e
+assert_eq "exit code propagated" "7" "$rc"
+assert_match "success=false"     '^success=false$'                       "$GITHUB_OUTPUT"
+
+echo "[6] fail-on-error=false returns 0 even when forge fails"
+: > "$GITHUB_OUTPUT"
+: > "$GITHUB_STEP_SUMMARY"
+FORGE_FAIL_ON_ERROR="false" bash scripts/run.sh > "$TMP/stdout.log" 2>&1
+rc=$?
+assert_eq "exit code suppressed" "0" "$rc"
+assert_match "success=false"     '^success=false$'                       "$GITHUB_OUTPUT"
+
+if [ "$failures" -eq 0 ]; then
+  echo
+  echo "All tests passed."
+  exit 0
+else
+  echo
+  echo "$failures test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Composite action that installs forge, executes a task, parses the completion block into outputs, writes a job summary, and (optionally) posts a PR comment.

- actions/forge-run/action.yml: inputs (task, mode, extra-args, forge-version, provider, comment, fail-on-error, cache-forge-home), outputs (success, task-id, summary, files-changed, duration-ms, cost-usd, log-path).
- actions/forge-run/scripts/run.sh: portable runner. Uses perl for millisecond timing (works on Linux/macOS/Windows runners). POSIX character classes in sed for BSD compat.
- actions/forge-run/test/run.test.sh: smoke tests with a stubbed forge binary covering the parse path, success/failure exit codes, and fail-on-error toggle.
- ci.yml: new action-tests job + pipeline-status integration.

This pull request introduces a new reusable GitHub Action for running Forge agentic coding tasks in CI, integrates smoke tests for this action into the main CI workflow, and updates documentation to reflect these changes. The most important changes are:

**GitHub Action: Forge Runner**

* Added a new composite GitHub Action in `actions/forge-run` that runs Forge tasks in various modes (`plan`, `balanced`, `risky`), parses outputs, and can post results as PR comments. It supports caching, provider selection, and detailed output fields. (`actions/forge-run/action.yml`, `actions/forge-run/scripts/run.sh`, [[1]](diffhunk://#diff-21d285ad4abab1bc790a86cfee721ea8d624d4af560216706cd3b33125c3d272R1-R136) [[2]](diffhunk://#diff-97583aac0295d216f98e3766a26b52fa6f1ee905de8cb6b85fc5394bea1a7ecdR1-R146)
* Provided comprehensive documentation for the new action, including usage examples, input/output reference, and security notes. (`actions/forge-run/README.md`, [actions/forge-run/README.mdR1-R163](diffhunk://#diff-45c0cf6a6311879bb2e3a8b5c0abb360aa539ce3ce2727bb1974b86815b47f38R1-R163))

**CI Workflow Integration**

* Added a new `action-tests` job to `.github/workflows/ci.yml` that smoke-tests the Forge runner script to ensure it works as expected. This job is now required before the pipeline status check.
* Updated the pipeline status summary and failure logic to include the result of the new `action-tests` job, ensuring failures in the Forge Action tests are visible in CI. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR368) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR393) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR406-R410)

**Documentation Updates**

* Updated the main `README.md` with a new section describing the Forge GitHub Action, a diagram update to include the action in the CI flow, and example usage.

These changes provide a robust, testable, and well-documented way to run Forge agentic coding tasks as part of any GitHub Actions workflow, with clear integration into the project's CI pipeline.
